### PR TITLE
Changed visibility of RESTClient to public

### DIFF
--- a/Grapevine/Client/RESTClient.cs
+++ b/Grapevine/Client/RESTClient.cs
@@ -8,7 +8,7 @@ namespace Grapevine.Client
     /// <summary>
     /// Represents a server exposing resources to interact with
     /// </summary>
-    class RESTClient
+    public class RESTClient
     {
         public RESTClient(string baseUrl)
         {


### PR DESCRIPTION
You can't actually use the RESTClient class right now due to the lack of public keyword
