### PR TITLE
Implemented Issue #102

### DIFF
--- a/src/Grapevine.Tests/Server/RouterFacts.cs
+++ b/src/Grapevine.Tests/Server/RouterFacts.cs
@@ -228,38 +228,85 @@ namespace Grapevine.Tests.Server
         public class InsertMethod
         {
             [Fact]
-            public void InsertBeforeByDefault()
-            {
-            }
-
-            [Fact]
             public void InsertsBeforeIndex()
             {
+                var routeA = new Route(context => context);
+                var routeB = new Route(context => context);
+                var routeC = new Route(context => context);
+
+                var router = new Router();
+                router.Register(routeA);
+                router.Register(routeB);
+                router.RoutingTable[1].ShouldBe(routeB);
+
+                router.Insert(1, routeC);
+                router.RoutingTable[1].ShouldBe(routeC);
+                router.RoutingTable[2].ShouldBe(routeB);
             }
 
             [Fact]
             public void InsertsToTop()
             {
+                var routeA = new Route(context => context);
+                var routeB = new Route(context => context);
+                var routeC = new Route(context => context);
+
+                var router = new Router();
+                router.Register(routeA);
+                router.Register(routeB);
+                router.RoutingTable[0].ShouldBe(routeA);
+
+                router.Insert(0, routeC);
+                router.RoutingTable[0].ShouldBe(routeC);
+                router.RoutingTable[1].ShouldBe(routeA);
             }
 
             [Fact]
             public void InsertsToBottom()
             {
-            }
+                var routeA = new Route(context => context);
+                var routeB = new Route(context => context);
+                var routeC = new Route(context => context);
 
-            [Fact]
-            public void InsertsAfterIndex()
-            {
+                var router = new Router();
+                router.Register(routeA);
+                router.Register(routeB);
+                router.Insert(2, routeC);
+
+                router.RoutingTable[2].ShouldBe(routeC);
             }
 
             [Fact]
             public void DoesNotInsertDuplicate()
             {
+                var routeA = new Route(context => context);
+                var routeB = new Route(context => context);
+
+                var router = new Router();
+                router.Register(routeA);
+                router.Register(routeB);
+                router.RoutingTable.Count.ShouldBe(2);
+
+                router.Insert(0, routeB);
+                router.RoutingTable[0].ShouldBe(routeA);
+                router.RoutingTable[1].ShouldBe(routeB);
+                router.RoutingTable.Count.ShouldBe(2);
             }
 
             [Fact]
             public void DoesNotInsertWhenIndexIsLessThanZero()
             {
+                var routeA = new Route(context => context);
+                var routeB = new Route(context => context);
+                var routeC = new Route(context => context);
+
+                var router = new Router();
+                router.Register(routeA);
+                router.Register(routeB);
+                router.RoutingTable.Count.ShouldBe(2);
+
+                router.Insert(-1, routeC);
+                router.RoutingTable.Count.ShouldBe(2);
             }
 
             [Fact]
@@ -279,11 +326,6 @@ namespace Grapevine.Tests.Server
 
             [Fact]
             public void InsertsListBeforeIndex()
-            {
-            }
-
-            [Fact]
-            public void InsertsListAfterIndex()
             {
             }
 

--- a/src/Grapevine.Tests/Server/RouterFacts.cs
+++ b/src/Grapevine.Tests/Server/RouterFacts.cs
@@ -225,6 +225,79 @@ namespace Grapevine.Tests.Server
             }
         }
 
+        public class InsertMethod
+        {
+            [Fact]
+            public void InsertBeforeByDefault()
+            {
+            }
+
+            [Fact]
+            public void InsertsBeforeIndex()
+            {
+            }
+
+            [Fact]
+            public void InsertsToTop()
+            {
+            }
+
+            [Fact]
+            public void InsertsToBottom()
+            {
+            }
+
+            [Fact]
+            public void InsertsAfterIndex()
+            {
+            }
+
+            [Fact]
+            public void DoesNotInsertDuplicate()
+            {
+            }
+
+            [Fact]
+            public void DoesNotInsertWhenIndexIsLessThanZero()
+            {
+            }
+
+            [Fact]
+            public void InsertsBeforeMarker()
+            {
+            }
+
+            [Fact]
+            public void InsertsAfterMarker()
+            {
+            }
+
+            [Fact]
+            public void DoesNotInsertWhenMarkerIsNotFound()
+            {
+            }
+
+            [Fact]
+            public void InsertsListBeforeIndex()
+            {
+            }
+
+            [Fact]
+            public void InsertsListAfterIndex()
+            {
+            }
+
+            [Fact]
+            public void InsertsListBeforeMarker()
+            {
+            }
+
+            [Fact]
+            public void InsertsListAfterMarker()
+            {
+            }
+        }
+
         public class LoggerProperty
         {
             [Fact]

--- a/src/Grapevine/Server/Router.cs
+++ b/src/Grapevine/Server/Router.cs
@@ -380,7 +380,7 @@ namespace Grapevine.Server
         public IRouter Insert(Ordinal ordinal, IRoute marker, IList<IRoute> routes)
         {
             var index = _routingTable.IndexOf(marker);
-            if (index > -1) routes.Aggregate(index, (current, route) => InsertAt(current, route));
+            if (index > -1) routes.Aggregate(index + (ordinal == Ordinal.Before ? 0 : 1), (current, route) => InsertAt(current, route));
             return this;
         }
 

--- a/src/Grapevine/Server/Router.cs
+++ b/src/Grapevine/Server/Router.cs
@@ -61,6 +61,54 @@ namespace Grapevine.Server
         IRouter Import<T>() where T : IRouter;
 
         /// <summary>
+        /// Inserts the route into the routing table immediately following the specified route (marker)
+        /// </summary>
+        /// <param name="route"></param>
+        /// <param name="marker"></param>
+        /// <returns></returns>
+        IRouter InsertAfter(IRoute route, IRoute marker);
+
+        /// <summary>
+        /// Inserts the routes into the routing table immediately following the specifed route (marker)
+        /// </summary>
+        /// <param name="routes"></param>
+        /// <param name="marker"></param>
+        /// <returns></returns>
+        IRouter InsertAfter(IList<IRoute> routes, IRoute marker);
+
+        /// <summary>
+        /// Inserts the route into the routing table at the specified index
+        /// </summary>
+        /// <param name="route"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        IRouter InsertRouteAt(IRoute route, int index);
+
+        /// <summary>
+        /// Inserts the routes into the routing table at the specified index
+        /// </summary>
+        /// <param name="routes"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        IRouter InsertRoutesAt(IList<IRoute> routes, int index);
+
+        /// <summary>
+        /// Inserts the route into the routing table immediately before the specified route (marker)
+        /// </summary>
+        /// <param name="route"></param>
+        /// <param name="marker"></param>
+        /// <returns></returns>
+        IRouter InsertRouteBefore(IRoute route, IRoute marker);
+
+        /// <summary>
+        /// Inserts the routes into the routing table immediately before the specified route (marker)
+        /// </summary>
+        /// <param name="routes"></param>
+        /// <param name="marker"></param>
+        /// <returns></returns>
+        IRouter InsertRoutesBefore(IList<IRoute> routes, IRoute marker);
+
+        /// <summary>
         /// Gets or sets the internal logger
         /// </summary>
         IGrapevineLogger Logger { get; set; }

--- a/src/Grapevine/Server/Router.cs
+++ b/src/Grapevine/Server/Router.cs
@@ -61,20 +61,22 @@ namespace Grapevine.Server
         IRouter Import<T>() where T : IRouter;
 
         /// <summary>
-        /// Inserts the route into the routing table immediately following the specified route (marker)
+        /// Inserts the route into the routing table either before or after the specified (marker) route
         /// </summary>
         /// <param name="route"></param>
+        /// <param name="ordinal"></param>
         /// <param name="marker"></param>
         /// <returns></returns>
-        IRouter InsertAfter(IRoute route, IRoute marker);
+        IRouter Insert(Ordinal ordinal, IRoute marker, IRoute route);
 
         /// <summary>
-        /// Inserts the routes into the routing table immediately following the specifed route (marker)
+        /// Inserts the routes into the routing table either before or after the specified (marker) route
         /// </summary>
         /// <param name="routes"></param>
+        /// <param name="ordinal"></param>
         /// <param name="marker"></param>
         /// <returns></returns>
-        IRouter InsertAfter(IList<IRoute> routes, IRoute marker);
+        IRouter Insert(Ordinal ordinal, IRoute marker, IList<IRoute> routes);
 
         /// <summary>
         /// Inserts the route into the routing table at the specified index
@@ -82,7 +84,7 @@ namespace Grapevine.Server
         /// <param name="route"></param>
         /// <param name="index"></param>
         /// <returns></returns>
-        IRouter InsertRouteAt(IRoute route, int index);
+        IRouter Insert(int index, IRoute route);
 
         /// <summary>
         /// Inserts the routes into the routing table at the specified index
@@ -90,23 +92,7 @@ namespace Grapevine.Server
         /// <param name="routes"></param>
         /// <param name="index"></param>
         /// <returns></returns>
-        IRouter InsertRoutesAt(IList<IRoute> routes, int index);
-
-        /// <summary>
-        /// Inserts the route into the routing table immediately before the specified route (marker)
-        /// </summary>
-        /// <param name="route"></param>
-        /// <param name="marker"></param>
-        /// <returns></returns>
-        IRouter InsertRouteBefore(IRoute route, IRoute marker);
-
-        /// <summary>
-        /// Inserts the routes into the routing table immediately before the specified route (marker)
-        /// </summary>
-        /// <param name="routes"></param>
-        /// <param name="marker"></param>
-        /// <returns></returns>
-        IRouter InsertRoutesBefore(IList<IRoute> routes, IRoute marker);
+        IRouter Insert(int index, IList<IRoute> routes);
 
         /// <summary>
         /// Gets or sets the internal logger
@@ -385,6 +371,38 @@ namespace Grapevine.Server
             return Import(typeof (T));
         }
 
+        public IRouter Insert(Ordinal ordinal, IRoute marker, IRoute route)
+        {
+            InsertAt(_routingTable.IndexOf(marker), route, ordinal);
+            return this;
+        }
+
+        public IRouter Insert(Ordinal ordinal, IRoute marker, IList<IRoute> routes)
+        {
+            var index = _routingTable.IndexOf(marker);
+            if (index > -1) routes.Aggregate(index, (current, route) => InsertAt(current, route));
+            return this;
+        }
+
+        public IRouter Insert(int index, IRoute route)
+        {
+            InsertAt(index, route);
+            return this;
+        }
+
+        public IRouter Insert(int index, IList<IRoute> routes)
+        {
+            routes.Aggregate(index, (current, route) => InsertAt(current, route));
+            return this;
+        }
+
+        private int InsertAt(int index, IRoute route, Ordinal ordinal = Ordinal.Before)
+        {
+            if (index < 0 || _routingTable.Contains(route)) return index;
+            _routingTable.Insert(index + (ordinal == Ordinal.Before ? 0 : 1), route);
+            return index + 1;
+        }
+
         public IList<IRoute> RouteFor(IHttpContext context)
         {
             return _routingTable.Where(r => r.Matches(context) && r.Enabled).ToList();
@@ -449,5 +467,11 @@ namespace Grapevine.Server
         {
             routes.ToList().ForEach(AddToRoutingTable);
         }
+    }
+
+    public enum Ordinal
+    {
+        After,
+        Before
     }
 }


### PR DESCRIPTION
Routes and lists of routes can be added to the routing table at specific indexes and before and after specific routes using the new `Router.Insert()` overloaded methods.