### PR TITLE
ContentType Detection with Parameters and Multiple Values Issue #129

### DIFF
--- a/src/Grapevine.Tests/Shared/ContentTypeFacts.cs
+++ b/src/Grapevine.Tests/Shared/ContentTypeFacts.cs
@@ -69,6 +69,18 @@ namespace Grapevine.Tests.Shared
                 {
                     ContentType.DEFAULT.FromString("application/json").Equals(ContentType.JSON).ShouldBeTrue();
                 }
+
+                [Fact]
+                public void ReturnsContentTypeFromStringWithParameters()
+                {
+                    ContentType.DEFAULT.FromString("text/html; charset=UTF-8").Equals(ContentType.HTML).ShouldBeTrue();
+                }
+
+                [Fact]
+                public void ReturnsContentTypeFromStringWithMultipleValues()
+                {
+                    ContentType.DEFAULT.FromString("text/html; charset=UTF-8,text/html; charset=windows-1251").Equals(ContentType.HTML).ShouldBeTrue();
+                }
             }
         }
 

--- a/src/Grapevine/Shared/ContentType.cs
+++ b/src/Grapevine/Shared/ContentType.cs
@@ -49,9 +49,15 @@ namespace Grapevine.Shared
 
         public static ContentType FromString(this ContentType ct, string contentType)
         {
-            return string.IsNullOrWhiteSpace(contentType)
-                ? ContentType.DEFAULT
-                : Enum.GetValues(typeof(ContentType)).Cast<ContentType>().FirstOrDefault(t => t.ToValue().Equals(contentType));
+            if (string.IsNullOrWhiteSpace(contentType)) return ContentType.DEFAULT;
+
+            var contenttype = contentType.Contains(";")
+                ? contentType.Substring(0, contentType.IndexOf(";", StringComparison.Ordinal))
+                : contentType.Contains(",")
+                    ? contentType.Substring(0, contentType.IndexOf(",", StringComparison.Ordinal))
+                    : contentType;
+
+            return Enum.GetValues(typeof(ContentType)).Cast<ContentType>().FirstOrDefault(t => t.ToValue().Equals(contenttype));
         }
     }
 
@@ -1015,10 +1021,10 @@ namespace Grapevine.Shared
         HTKE,
 
         [ContentTypeMetadata(Value = "text/html", IsText = true)]
-        HTM,
+        HTML,
 
         [ContentTypeMetadata(Value = "text/html", IsText = true)]
-        HTML,
+        HTM,
 
         [ContentTypeMetadata(Value = "application/vnd.yamaha.hv-dic", IsBinary = true)]
         HVD,


### PR DESCRIPTION
Fixes issue #129

`ContentType` headers with multiple values and/or parameters are now correctly parsed and detected.