### PR TITLE
Enhanced ContentType Parsing and Referencing

### DIFF
--- a/src/Grapevine.Tests/Shared/ContentTypeFacts.cs
+++ b/src/Grapevine.Tests/Shared/ContentTypeFacts.cs
@@ -54,32 +54,39 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void ReturnsDefaultWhenParameterIsNullOrEmpty()
                 {
-                    ContentType.DEFAULT.FromString(null).Equals(ContentType.DEFAULT).ShouldBeTrue();
-                    ContentType.DEFAULT.FromString(string.Empty).Equals(ContentType.DEFAULT).ShouldBeTrue();
+                    ContentType.CUSTOM_TEXT.FromString(null).Equals(ContentType.CUSTOM_TEXT).ShouldBeTrue();
+                    ContentType.CUSTOM_TEXT.FromString(string.Empty).Equals(ContentType.CUSTOM_TEXT).ShouldBeTrue();
                 }
 
                 [Fact]
                 public void ReturnsDefaultWhenParameterIsNotInEnum()
                 {
-                    ContentType.DEFAULT.FromString("test").Equals(ContentType.DEFAULT).ShouldBeTrue();
+                    ContentType.CUSTOM_TEXT.FromString("test").Equals(ContentType.CUSTOM_TEXT).ShouldBeTrue();
                 }
 
                 [Fact]
                 public void ReturnsContentTypeFromString()
                 {
-                    ContentType.DEFAULT.FromString("application/json").Equals(ContentType.JSON).ShouldBeTrue();
+                    ContentType.CUSTOM_TEXT.FromString("application/json").Equals(ContentType.JSON).ShouldBeTrue();
                 }
 
                 [Fact]
                 public void ReturnsContentTypeFromStringWithParameters()
                 {
-                    ContentType.DEFAULT.FromString("text/html; charset=UTF-8").Equals(ContentType.HTML).ShouldBeTrue();
+                    ContentType.CUSTOM_TEXT.FromString("text/html; charset=UTF-8").Equals(ContentType.HTML).ShouldBeTrue();
                 }
 
                 [Fact]
                 public void ReturnsContentTypeFromStringWithMultipleValues()
                 {
-                    ContentType.DEFAULT.FromString("text/html; charset=UTF-8,text/html; charset=windows-1251").Equals(ContentType.HTML).ShouldBeTrue();
+                    ContentType.CUSTOM_TEXT.FromString("text/html,text/plain").Equals(ContentType.HTML).ShouldBeTrue();
+                }
+
+                [Fact]
+                public void ReturnsContentTypeFromStringWithMultipleValuesWithParameters()
+                {
+                    ContentType.CUSTOM_TEXT.FromString("text/html,text/plain; charset=windows-1251").Equals(ContentType.HTML).ShouldBeTrue();
+                    ContentType.CUSTOM_TEXT.FromString("text/html; charset=UTF-8,text/plain").Equals(ContentType.HTML).ShouldBeTrue();
                 }
             }
         }

--- a/src/Grapevine/Client/RestResponse.cs
+++ b/src/Grapevine/Client/RestResponse.cs
@@ -155,7 +155,7 @@ namespace Grapevine.Client
         {
             _response = response;
             Advanced = new AdvancedRestResponse(_response);
-            ContentType = ContentType.DEFAULT.FromString(_response.ContentType);
+            ContentType = ContentType.CUSTOM_TEXT.FromString(_response.ContentType);
             Error = string.Empty;
             ErrorStatus = WebExceptionStatus.Success;
             HttpMethod = (HttpMethod)Enum.Parse(typeof(HttpMethod), _response.Method);

--- a/src/Grapevine/Interfaces/Server/HttpResponse.cs
+++ b/src/Grapevine/Interfaces/Server/HttpResponse.cs
@@ -366,7 +366,7 @@ namespace Grapevine.Interfaces.Server
             var ext = Path.GetExtension(filepath)?.ToUpper().TrimStart('.');
             return !string.IsNullOrWhiteSpace(ext) && Enum.IsDefined(typeof(ContentType), ext)
                 ? (ContentType)Enum.Parse(typeof(ContentType), ext)
-                : ContentType.DEFAULT;
+                : ContentType.CUSTOM_TEXT;
         }
 
         /// <summary>
@@ -433,6 +433,12 @@ namespace Grapevine.Interfaces.Server
         internal AdvancedHttpResponse(HttpResponse response)
         {
             _response = response;
+        }
+
+        public string ContentType
+        {
+            get { return _response.Response.ContentType; }
+            set { _response.Response.ContentType = value; }
         }
 
         /// <summary>

--- a/src/Grapevine/Shared/ContentType.cs
+++ b/src/Grapevine/Shared/ContentType.cs
@@ -49,14 +49,9 @@ namespace Grapevine.Shared
 
         public static ContentType FromString(this ContentType ct, string contentType)
         {
-            if (string.IsNullOrWhiteSpace(contentType)) return ContentType.DEFAULT;
+            if (string.IsNullOrWhiteSpace(contentType)) return ContentType.CUSTOM_TEXT;
 
-            var contenttype = contentType.Contains(";")
-                ? contentType.Substring(0, contentType.IndexOf(";", StringComparison.Ordinal))
-                : contentType.Contains(",")
-                    ? contentType.Substring(0, contentType.IndexOf(",", StringComparison.Ordinal))
-                    : contentType;
-
+            var contenttype = contentType.Split(';', ',')[0];
             return Enum.GetValues(typeof(ContentType)).Cast<ContentType>().FirstOrDefault(t => t.ToValue().Equals(contenttype));
         }
     }
@@ -99,6 +94,12 @@ namespace Grapevine.Shared
     /// </summary>
     public enum ContentType
     {
+        [ContentTypeMetadata(Value = "text/plain", IsText = true)]
+        CUSTOM_TEXT,
+
+        [ContentTypeMetadata(Value = "application/octet-stream", IsBinary = true)]
+        CUSTOM_BINARY,
+
         [ContentTypeMetadata(Value = "application/octet-stream", IsBinary = true)]
         DEFAULT,
 

--- a/src/Grapevine/Shared/HttpMethod.cs
+++ b/src/Grapevine/Shared/HttpMethod.cs
@@ -36,7 +36,5 @@
         {
             return httpMethod == HttpMethod.ALL || other == HttpMethod.ALL || httpMethod == other;
         }
-
-
     }
 }


### PR DESCRIPTION
Fixes #129 

- Simplified ContentType.FromString parsing
- Made the raw ContentType string value available to the server Request and
  Response via their respective Advanced.ContentType. Can be directly set on
  the Response if there is not a value in the Enum that matches.
- Added CUSTOM_TEXT and CUSTOM_BINARY to the ContentType enum

To set a custom content type value, set Response.ContentType to either
CUSTOM_TEXT or CUSTOM_BINARY (depending on whether you want to send a text
or binary response), and then set Response.Advanced.ContentType to the
custom value. It must be done in this order, because setting the
Response.ContentType value writes directly to
Response.Advanced.ContentType.