### PR TITLE
Parsing Multi-Value and Malformed Content-Type Http Header

### DIFF
--- a/src/Grapevine.Tests/Shared/ContentTypeFacts.cs
+++ b/src/Grapevine.Tests/Shared/ContentTypeFacts.cs
@@ -89,6 +89,44 @@ namespace Grapevine.Tests.Shared
                     ContentType.CUSTOM_TEXT.FromString("text/html,text/plain; charset=windows-1251").Equals(ContentType.HTML).ShouldBeTrue();
                     ContentType.CUSTOM_TEXT.FromString("text/html; charset=UTF-8,text/plain").Equals(ContentType.HTML).ShouldBeTrue();
                 }
+
+                [Fact]
+                public void MaintainsPerformance()
+                {
+                    const int cycles = 1000;
+                    const ContentType ct = ContentType.DEFAULT;
+                    const long maxThreshold = 50000;
+                    const long minThreshold = 1000;
+
+                    ct.FromString("application/json,text/json").ShouldBe(ContentType.JSON);
+                    ct.FromString("chemical/x-xyz").ShouldBe(ContentType.XYZ);
+                    ct.FromString("video/x-ms-wvx").ShouldBe(ContentType.WVX);
+                    ct.FromString("text/x-vcalendar").ShouldBe(ContentType.VCS);
+                    ct.FromString("application/jsonml+json").ShouldBe(ContentType.JSONML);
+                    ct.FromString("application/pdf").ShouldBe(ContentType.PDF);
+                    ct.FromString("image/x-pcx").ShouldBe(ContentType.PCX);
+                    ct.FromString("application/vnd.ms-powerpoint.template.macroenabled.12").ShouldBe(ContentType.POTM);
+                    ct.FromString("application/vnd.businessobjects").ShouldBe(ContentType.REP);
+                    ct.FromString("image/x-mrsid-image").ShouldBe(ContentType.SID);
+
+                    var sw = Stopwatch.StartNew();
+                    for (var i = 0; i < cycles; i++)
+                    {
+                        var a = ct.FromString("application/json,text/json");
+                        var b = ct.FromString("chemical/x-xyz");
+                        var c = ct.FromString("video/x-ms-wvx");
+                        var d = ct.FromString("text/x-vcalendar");
+                        var e = ct.FromString("application/jsonml+json");
+                        var f = ct.FromString("application/pdf");
+                        var g = ct.FromString("image/x-pcx");
+                        var h = ct.FromString("application/vnd.ms-powerpoint.template.macroenabled.12");
+                        var j = ct.FromString("application/vnd.businessobjects");
+                        var k = ct.FromString("image/x-mrsid-image");
+                    }
+                    sw.Stop();
+
+                    sw.ElapsedTicks.ShouldBeInRange(minThreshold, maxThreshold);
+                }
             }
         }
 

--- a/src/Grapevine.sln
+++ b/src/Grapevine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Grapevine", "Grapevine\Grapevine.csproj", "{C79E6853-F7A0-426F-883C-169651123256}"
 EndProject

--- a/src/Grapevine/Client/RestRequest.cs
+++ b/src/Grapevine/Client/RestRequest.cs
@@ -254,6 +254,7 @@ namespace Grapevine.Client
         public static int GlobalTimeout = 100000;
 
         private string _resource;
+        private ContentType _contentType;
 
         public string Accept { get; set; }
         public bool AllowAutoRedirect { get; set; }
@@ -265,7 +266,6 @@ namespace Grapevine.Client
         public string Connection { get; set; }
         public string ConnectionGroupName { get; set; }
         public long ContentLength { get; set; }
-        public ContentType ContentType { get; set; }
         public HttpContinueDelegate ContinueDelegate { get; set; }
         public ICredentials Credentials { get; set; }
         public DateTime Date { get; set; }
@@ -339,6 +339,16 @@ namespace Grapevine.Client
             Timeout = GlobalTimeout;
         }
 
+        public ContentType ContentType
+        {
+            get { return _contentType; }
+            set
+            {
+                _contentType = value;
+                Advanced.ContentType = _contentType.ToValue();
+            }
+        }
+
         public string Resource
         {
             get
@@ -377,7 +387,10 @@ namespace Grapevine.Client
         internal AdvancedRestRequest(RestRequest request)
         {
             _request = request;
+            ContentType = _request.ContentType.ToValue();
         }
+
+        public string ContentType { get; set; }
 
         /// <summary>
         /// Gets the current request as an HttpWebRequest
@@ -404,7 +417,7 @@ namespace Grapevine.Client
             request.Connection = _request.Connection;
             request.ConnectionGroupName = _request.ConnectionGroupName;
             request.ContentLength = _request.ContentLength;
-            request.ContentType = _request.ContentType.ToValue();
+            request.ContentType = ContentType;
             request.ContinueDelegate = _request.ContinueDelegate;
             request.CookieContainer = cookies;
             request.Credentials = _request.Credentials;

--- a/src/Grapevine/Client/RestResponse.cs
+++ b/src/Grapevine/Client/RestResponse.cs
@@ -125,11 +125,12 @@ namespace Grapevine.Client
     {
         private readonly HttpWebResponse _response;
         private string _content;
+        private ContentType _contentType;
+        private bool _parsedContentType;
 
         public string CharacterSet => _response.CharacterSet;
         public string ContentEncoding => _response.ContentEncoding;
         public long ContentLength => _response.ContentLength;
-        public ContentType ContentType { get; }
         public CookieCollection Cookies => _response.Cookies;
         public long ElapsedTime { get; protected internal set; }
         public string Error { get; protected internal set; }
@@ -155,11 +156,21 @@ namespace Grapevine.Client
         {
             _response = response;
             Advanced = new AdvancedRestResponse(_response);
-            ContentType = ContentType.CUSTOM_TEXT.FromString(_response.ContentType);
             Error = string.Empty;
             ErrorStatus = WebExceptionStatus.Success;
-            HttpMethod = (HttpMethod)Enum.Parse(typeof(HttpMethod), _response.Method);
+            HttpMethod = HttpMethod.ALL.FromString(_response.Method);
             StatusCode = (HttpStatusCode) (int) _response.StatusCode;
+        }
+
+        public ContentType ContentType
+        {
+            get
+            {
+                if (_parsedContentType) return _contentType;
+                _contentType = _contentType.FromString(_response.ContentType);
+                _parsedContentType = true;
+                return _contentType;
+            }
         }
 
         public string GetContent()

--- a/src/Grapevine/Interfaces/Server/HttpRequest.cs
+++ b/src/Grapevine/Interfaces/Server/HttpRequest.cs
@@ -199,6 +199,8 @@ namespace Grapevine.Interfaces.Server
     public class HttpRequest : IHttpRequest
     {
         private string _payload;
+        private ContentType _contentType;
+        private bool _parsedContentType;
 
         /// <summary>
         /// The underlying HttpListenerRequest for this instance
@@ -228,7 +230,16 @@ namespace Grapevine.Interfaces.Server
 
         public long ContentLength64 => Request.ContentLength64;
 
-        public ContentType ContentType => ContentType.DEFAULT.FromString(Request.ContentType);
+        public ContentType ContentType
+        {
+            get
+            {
+                if (_parsedContentType) return _contentType;
+                _contentType = _contentType.FromString(Request.ContentType);
+                _parsedContentType = true;
+                return _contentType;
+            }
+        }
 
         public CookieCollection Cookies => Request.Cookies;
 

--- a/src/Grapevine/Interfaces/Server/HttpResponse.cs
+++ b/src/Grapevine/Interfaces/Server/HttpResponse.cs
@@ -158,6 +158,9 @@ namespace Grapevine.Interfaces.Server
 
     public class HttpResponse : IHttpResponse
     {
+        private ContentType _contentType;
+        private bool _parsedContentType;
+
         /// <summary>
         /// Used to set the umber of hours before sent content expires on the Expires response header
         /// </summary>
@@ -202,8 +205,19 @@ namespace Grapevine.Interfaces.Server
 
         public ContentType ContentType
         {
-            get { return Enum.GetValues(typeof (ContentType)).Cast<ContentType>().First(t => t.ToValue().Equals(Response.ContentType)); }
-            set { Response.ContentType = value.ToValue(); }
+            get
+            {
+                if (_parsedContentType) return _contentType;
+                _contentType = _contentType.FromString(Response.ContentType);
+                _parsedContentType = true;
+                return _contentType;
+            }
+            set
+            {
+                _contentType = value;
+                Response.ContentType = _contentType.ToValue();
+                _parsedContentType = true;
+            }
         }
 
         public CookieCollection Cookies

--- a/src/Grapevine/Shared/HttpMethod.cs
+++ b/src/Grapevine/Shared/HttpMethod.cs
@@ -1,4 +1,8 @@
-﻿namespace Grapevine.Shared
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace Grapevine.Shared
 {
     /// <summary>
     /// Http methods (or verbs) to indicate the desired action to be performed on the resource
@@ -26,6 +30,19 @@
 
     public static class HttpMethodExtensions
     {
+        private static readonly ConcurrentDictionary<string, int> Lookup;
+
+        static HttpMethodExtensions()
+        {
+            Lookup = new ConcurrentDictionary<string, int>();
+
+            foreach (var val in Enum.GetValues(typeof(HttpMethod)).Cast<HttpMethod>())
+            {
+                var key = val.ToString();
+                if (!Lookup.ContainsKey(key)) Lookup[key] = (int)val;
+            }
+        }
+
         /// <summary>
         /// Gets a value indicating whether the HttpMethods are equal OR one of them is HttpMethod.ALL
         /// </summary>
@@ -35,6 +52,17 @@
         public static bool IsEquivalent(this HttpMethod httpMethod, HttpMethod other)
         {
             return httpMethod == HttpMethod.ALL || other == HttpMethod.ALL || httpMethod == other;
+        }
+
+        /// <summary>
+        ///  Returns an HttpMethod value for the method string provided
+        /// </summary>
+        /// <param name="httpMethod"></param>
+        /// <param name="method"></param>
+        /// <returns></returns>
+        public static HttpMethod FromString(this HttpMethod httpMethod, string method)
+        {
+            return (Lookup.ContainsKey(method)) ? (HttpMethod) Lookup[method] : 0;
         }
     }
 }


### PR DESCRIPTION
Added logic to parsing the Content-Type http header to use a dictionary
for lookups, cache results for future lookups and check all values when
multiple values are provided for a match.

Added dictionary for http method lookups.

Fixes #136