### PR TITLE
Change Properties Implementation To Use ConcurrentDictionary

### DIFF
--- a/src/Grapevine.Tests/Shared/ContentTypeFacts.cs
+++ b/src/Grapevine.Tests/Shared/ContentTypeFacts.cs
@@ -135,27 +135,39 @@ namespace Grapevine.Tests.Shared
                 private const ContentType DefaultContentType = 0;
 
                 [Fact]
+                public void ReturnsDefaulttWhenArgumentIsNull()
+                {
+                    DefaultContentType.FromExtension(null).ShouldBe(DefaultContentType);
+                }
+
+                [Fact]
+                public void ReturnsDefaulttWhenArgumentIsEmpty()
+                {
+                    DefaultContentType.FromExtension(string.Empty).ShouldBe(DefaultContentType);
+                }
+
+                [Fact]
                 public void ReturnsDefaultWhenNoExtensionOnArgument()
                 {
-                    ContentType.DEFAULT.FromExtension("/ihavenoextension").ShouldBe(DefaultContentType);
+                    DefaultContentType.FromExtension("/ihavenoextension").ShouldBe(DefaultContentType);
                 }
 
                 [Fact]
                 public void ReturnsDefaultWhenExtentionNotInEnum()
                 {
-                    ContentType.DEFAULT.FromExtension("/thisextention.doesnotexist").ShouldBe(DefaultContentType);
+                    DefaultContentType.FromExtension("/thisextention.doesnotexist").ShouldBe(DefaultContentType);
                 }
 
                 [Fact]
                 public void ReturnsEnumFromExtension()
                 {
-                    ContentType.DEFAULT.FromExtension("/image.jpg").ShouldBe(ContentType.JPG);
+                    DefaultContentType.FromExtension("/image.jpg").ShouldBe(ContentType.JPG);
                 }
 
                 [Fact]
                 public void HtmlExtensionReturnsHtmlContentType()
                 {
-                    ContentType.DEFAULT.FromExtension("page.html").ShouldBe(ContentType.HTML);
+                    DefaultContentType.FromExtension("page.html").ShouldBe(ContentType.HTML);
                 }
             }
         }

--- a/src/Grapevine.Tests/Shared/DynamicPropertiesFact.cs
+++ b/src/Grapevine.Tests/Shared/DynamicPropertiesFact.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using Grapevine.Exceptions.Server;
 using Grapevine.Shared;
-using Microsoft.CSharp.RuntimeBinder;
 using Shouldly;
 using Xunit;
 
@@ -10,15 +10,15 @@ namespace Grapevine.Tests.Shared
 {
     public class DynamicPropertiesFact
     {
-        public class ConstructorMethod
+        public class Constructors
         {
             [Fact]
-            public void DynamicPropertyNotInitializedUntilFirstAccess()
+            public void PropertyNotInitializedUntilFirstAccess()
             {
-                var props = new ConcreteDynmProp();
+                var props = new ObjectWithProperties();
                 props.IsInitialized.ShouldBeFalse();
 
-                props.Properties.Key = "value";
+                props.Properties["Key"] = "value";
 
                 props.IsInitialized.ShouldBeTrue();
             }
@@ -29,17 +29,17 @@ namespace Grapevine.Tests.Shared
             [Fact]
             public void StoresAndReturnsValue()
             {
-                var props = new ConcreteDynmProp();
-                props.Properties.Key = "value";
-                var val = props.Properties.Key;
+                var props = new ObjectWithProperties();
+                props.Properties["Key"] = "value";
+                var val = props.Properties["Key"];
                 Assert.True(val.Equals("value"));
             }
 
             [Fact]
             public void ThrowsExceptionWhenIndexDoesNotExists()
             {
-                var props = new ConcreteDynmProp();
-                Should.Throw<RuntimeBinderException>(() => props.Properties.Key);
+                var props = new ObjectWithProperties();
+                Should.Throw<KeyNotFoundException>(() => { var x = props.Properties["Key"]; });
             }
         }
 
@@ -50,8 +50,8 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void ReturnsValueAsSpecifiedType()
                 {
-                    var props = new ConcreteDynmProp();
-                    props.Properties.Key = "value";
+                    var props = new ObjectWithProperties();
+                    props.Properties["Key"] = "value";
 
                     var val = props.GetPropertyValueAs<string>("Key");
 
@@ -62,8 +62,8 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void ThrowsExceptionWhenKeyIsNull()
                 {
-                    var props = new ConcreteDynmProp();
-                    props.Properties.Key = "value";
+                    var props = new ObjectWithProperties();
+                    props.Properties["Key"] = "value";
 
                     Should.Throw<ArgumentNullException>(() => props.GetPropertyValueAs<string>(null));
                 }
@@ -71,8 +71,8 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void ThrowsExceptionWhenKeyIsEmptyString()
                 {
-                    var props = new ConcreteDynmProp();
-                    props.Properties.Key = "value";
+                    var props = new ObjectWithProperties();
+                    props.Properties["Key"] = "value";
 
                     Should.Throw<ArgumentException>(() => props.GetPropertyValueAs<string>(string.Empty));
                     Should.Throw<ArgumentException>(() => props.GetPropertyValueAs<string>(""));
@@ -81,8 +81,8 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void ThrowsExceptionWhenKeyIsNotFound()
                 {
-                    var props = new ConcreteDynmProp();
-                    props.Properties.Key = "value";
+                    var props = new ObjectWithProperties();
+                    props.Properties["Key"] = "value";
 
                     Should.Throw<DynamicValueNotFoundException>(() => props.GetPropertyValueAs<string>("AnotheKey"));
                 }
@@ -90,8 +90,8 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void CovertsBetweenTypes()
                 {
-                    var props = new ConcreteDynmProp();
-                    props.Properties.MyNumber = 50;
+                    var props = new ObjectWithProperties();
+                    props.Properties["MyNumber"] = 50;
 
                     var val = props.GetPropertyValueAs<string>("MyNumber");
 
@@ -102,8 +102,8 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void ThrowsExcecptionWhenCanNotConvert()
                 {
-                    var props = new ConcreteDynmProp();
-                    props.Properties.Key = "value";
+                    var props = new ObjectWithProperties();
+                    props.Properties["Key"] = "value";
                     Should.Throw<InvalidCastException>(() => props.GetPropertyValueAs<FakeType>("Key"));
                 }
 
@@ -114,14 +114,14 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void ThrowsExceptionWhenKeyIsNull()
                 {
-                    var props = new ConcreteDynmProp();
+                    var props = new ObjectWithProperties();
                     Should.Throw<ArgumentNullException>(() => props.ContainsProperty(null));
                 }
 
                 [Fact]
                 public void ThrowsExceptionWhenKeyIsEmptyString()
                 {
-                    var props = new ConcreteDynmProp();
+                    var props = new ObjectWithProperties();
                     Should.Throw<ArgumentException>(() => props.ContainsProperty(string.Empty));
                     Should.Throw<ArgumentException>(() => props.ContainsProperty(""));
                 }
@@ -129,26 +129,26 @@ namespace Grapevine.Tests.Shared
                 [Fact]
                 public void ReturnsTrueWhenPropertyExists()
                 {
-                    var props = new ConcreteDynmProp();
-                    props.Properties.Key = "value";
+                    var props = new ObjectWithProperties();
+                    props.Properties["Key"] = "value";
                     props.ContainsProperty("Key").ShouldBeTrue();
                 }
 
                 [Fact]
                 public void ReturnsFalseWhenPropertyDoesNotExist()
                 {
-                    var props = new ConcreteDynmProp();
+                    var props = new ObjectWithProperties();
                     props.ContainsProperty("Key1").ShouldBeFalse();
                 }
             }
         }
     }
 
-    public class ConcreteDynmProp : DynamicProperties
+    public class ObjectWithProperties : DynamicProperties
     {
         private static FieldInfo _fieldInfo;
 
-        public ConcreteDynmProp()
+        public ObjectWithProperties()
         {
             if (_fieldInfo != null) return;
             var memberInfo = GetType().BaseType;

--- a/src/Grapevine.Tests/Shared/InternalExtensionsFacts.cs
+++ b/src/Grapevine.Tests/Shared/InternalExtensionsFacts.cs
@@ -22,6 +22,61 @@ namespace Grapevine.Tests.Shared
             }
         }
 
+        public class ObjectExtensions
+        {
+            public class TryDisposing
+            {
+                [Fact]
+                public void ReturnsTrueOnNonDisposableObjects()
+                {
+                    var ndo = new NonDisposable();
+                    ndo.TryDisposing().ShouldBeTrue();
+                    ndo.Disposed.ShouldBeFalse();
+                }
+
+                [Fact]
+                public void ReturnsTrueOnImplicityDisposableObject()
+                {
+                    var ido = new ImplicityDisposable();
+                    ido.TryDisposing().ShouldBeTrue();
+                    ido.Disposed.ShouldBeTrue();
+                }
+
+                [Fact]
+                public void ReturnsTrueOnExplicitlyDisposableObjects()
+                {
+                    var edo = new ExplicitlyDisposable();
+                    edo.TryDisposing().ShouldBeTrue();
+                    edo.Disposed.ShouldBeTrue();
+                }
+
+                public class NonDisposable
+                {
+                    public bool Disposed { get; protected set; }
+                }
+
+                public class ImplicityDisposable : IDisposable
+                {
+                    public bool Disposed { get; protected set; }
+
+                    public void Dispose()
+                    {
+                        Disposed = true;
+                    }
+                }
+
+                public class ExplicitlyDisposable : IDisposable
+                {
+                    public bool Disposed { get; protected set; }
+
+                    void IDisposable.Dispose()
+                    {
+                        Disposed = true;
+                    }
+                }
+            }
+        }
+
         public class StringExtensions
         {
             public class ConvertCamelCaseMethod

--- a/src/Grapevine/Server/Route.cs
+++ b/src/Grapevine/Server/Route.cs
@@ -259,8 +259,6 @@ namespace Grapevine.Server
                 return context => (IHttpContext) method.Invoke(null, new object[] {context});
             }
 
-            method.ReflectedType.CacheDisposablility();
-
             // Generates new instance every time
             return context =>
             {
@@ -278,7 +276,7 @@ namespace Grapevine.Server
                 }
             };
 
-            // TODO: Create and used a cached instance, like in earlier versions of Grapevine?
+            // TODO: Create and use a cached instance, like in earlier versions of Grapevine?
         }
     }
 

--- a/src/Grapevine/Shared/InternalExtensions.cs
+++ b/src/Grapevine/Shared/InternalExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -11,8 +10,6 @@ namespace Grapevine.Shared
     {
         private static readonly Regex CamelCaseInner = new Regex(@"(\P{Ll})(\P{Ll}\p{Ll})", RegexOptions.Singleline | RegexOptions.Compiled);
         private static readonly Regex CamelCaseOuter = new Regex(@"(\p{Ll})(\P{Ll})", RegexOptions.Singleline | RegexOptions.Compiled);
-
-        private static readonly ConcurrentDictionary<Type, bool> CanDispose = new ConcurrentDictionary<Type, bool>();
 
         /// <summary>
         /// Returns the string with spaces between inserted in the camel casing.
@@ -33,21 +30,9 @@ namespace Grapevine.Shared
         /// <param name="obj"></param>
         internal static bool TryDisposing(this object obj)
         {
-            if (CanDispose[obj.GetType()]) ((IDisposable)obj).Dispose();
+            if (!obj.GetType().Implements<IDisposable>()) return true;
+            ((IDisposable) obj).Dispose();
             return true;
-        }
-
-        internal static void CacheDisposablility(this Type type)
-        {
-            if (CanDispose.ContainsKey(type)) return;
-            if (!type.Implements<IDisposable>())
-            {
-                CanDispose.TryAdd(type, false);
-                return;
-            }
-
-            var method = type.GetMethod("Dispose", BindingFlags.Instance | BindingFlags.Public, null, Type.EmptyTypes, null);
-            CanDispose.TryAdd(type, method != null);
         }
 
         /// <summary>


### PR DESCRIPTION
This changes the DynamicProperties implementation use a `ConcurrentDictionary` instead of an `ExpandoObject` under the hood, as per #149.