### PR TITLE
Enabling to create new objects using another method (Ninject for example)

### DIFF
--- a/src/Grapevine/Server/Attributes/RestRoute.cs
+++ b/src/Grapevine/Server/Attributes/RestRoute.cs
@@ -74,8 +74,8 @@ namespace Grapevine.Server.Attributes
             // Can the method be invoked?
             if (!method.CanInvoke()) exceptions.Add(new InvalidRouteMethodException($"{method.Name} cannot be invoked"));
 
-            // Does the type have a parameterless constructor?
-            if (method.ReflectedType != null && !method.ReflectedType.HasParameterlessConstructor()) exceptions.Add(new InvalidRouteMethodException($"{method.Name} does not have a parameterless constructor"));
+            if (RestServer.CustomCreateInstance == null && method.ReflectedType != null && !method.ReflectedType.HasParameterlessConstructor())
+                exceptions.Add(new InvalidRouteMethodException($"{method.Name} does not have a parameterless constructor"));
 
             // Can not have a special name (getters and setters)
             if (method.IsSpecialName) exceptions.Add(new InvalidRouteMethodException($"{method.Name} may be treated in a special way by some compilers (such as property accessors and operator overloading methods)"));

--- a/src/Grapevine/Server/RestServer.cs
+++ b/src/Grapevine/Server/RestServer.cs
@@ -74,6 +74,8 @@ namespace Grapevine.Server
 
         public RestServer() : this(new ServerSettings()) { }
 
+        public static Func<Type, object> CustomCreateInstance;
+
         protected internal RestServer(IHttpListener listener) : this(new ServerSettings())
         {
             TestingMode = true;

--- a/src/Grapevine/Server/Route.cs
+++ b/src/Grapevine/Server/Route.cs
@@ -263,7 +263,7 @@ namespace Grapevine.Server
             // Generates new instance every time
             return context =>
             {
-                var instance = Activator.CreateInstance(method.ReflectedType);
+                var instance = RestServer.CustomCreateInstance == null ? Activator.CreateInstance(method.ReflectedType) : RestServer.CustomCreateInstance(method.ReflectedType);
                 var disposed = false;
                 try
                 {


### PR DESCRIPTION
With this commit you can define a way on how grapevine will generate objects for you, follows an example using ninject:

IKernel kernel = new StandardKernel(new INinjectModule[] { new Whatever() });

Grapevine.Server.RestServer.CustomCreateInstance = (Type p) =>
{
         return kernel.Get(p);
};