### PR TITLE
Fixed Router having Logger not set correctly

### DIFF
--- a/src/Grapevine/Server/RestServer.cs
+++ b/src/Grapevine/Server/RestServer.cs
@@ -88,10 +88,10 @@ namespace Grapevine.Server
 
             options.CloneEventHandlers(this);
             Host = options.Host;
-            Logger = options.Logger;
             Port = options.Port;
             PublicFolders = options.PublicFolders;
             Router = options.Router;
+            Logger = options.Logger;
             UseHttps = options.UseHttps;
 
             /* Obsolete */


### PR DESCRIPTION
When constructing `RestServer` with `ServerSettings`, when not changing the Logger after construction, the `RestServer.Router` will not have the correct `Logger`.

```csharp
ServerSettings settings = new ServerSettings();
setting.Logger = new FileLogger("output.log");
//where FileLogger is a custom logger which directs logs to file, for example

using (var server = new RestServer(setting))
{
    server.Start();
    Console.ReadLine();
    server.Stop();
}
```

The above code will not log the Router's logging as the Router will have a `NullLogger`.

Before this fix, in the current constructor of `RestServer`, the `Router` property is set after the `Logger` property, causing the value of the `Router.Logger` property to not be set to the same value.

In the setter of the `RestServer.Logger` property, when the `Logger` is changed, the `Router` will have its `Logger` changed. The fix essentially just sets the `Router` property before the `Logger` in the `RestServer` constructor, causing the `Router.Logger` property to be set to the same value when the `RestServer.Logger` property is changed during construction.