### PR TITLE
Fixes test RouterFacts\SendsInternalServerErrorResponseWhenExceptionThrown

### DIFF
--- a/src/Grapevine/Server/Router.cs
+++ b/src/Grapevine/Server/Router.cs
@@ -554,7 +554,7 @@ namespace Grapevine.Server
 
                 if (context.WasRespondedTo) return;
 
-                var status = (context.Response.StatusCode == HttpStatusCode.Ok) ? HttpStatusCode.InternalServerError : context.Response.StatusCode;
+                var status = (context.Response.StatusCode == HttpStatusCode.Ok) ? context.Response.StatusCode : HttpStatusCode.InternalServerError;
                 if (e is NotFoundException) status = HttpStatusCode.NotFound;
                 if (e is NotImplementedException) status = HttpStatusCode.NotImplemented;
 


### PR DESCRIPTION
Exceptions caught in Router.Route(Object) do result in a SendResponse call, but with an invalid status code of 0, due to what looks like an accidental swap in the ternary if.