### PR TITLE
Added Register(object instance, string pathInfo)

### DIFF
--- a/src/Grapevine.Tests/Server/RouterFacts.cs
+++ b/src/Grapevine.Tests/Server/RouterFacts.cs
@@ -797,10 +797,10 @@ namespace Grapevine.Tests.Server
                 var router = new Router();
                 router.RoutingTable.ShouldBeEmpty();
 
-                router.Register(new RoutesFromInstance(), "v2");
+                router.Register(new TypeWithBasePath(), "v2");
 
                 router.RoutingTable.Count.ShouldBe(1);
-                router.RoutingTable.First().PathInfo.ShouldContain("v2/api");
+                router.RoutingTable.First().PathInfo.ShouldContain("v2/with");
             }
 
             [Fact]
@@ -1279,7 +1279,7 @@ namespace Grapevine.Tests.Server
             throw new NotImplementedException();
         }
 
-        public IRouter Register<T>(T instance, string pathInfo = null) where T : class
+        public IRouter Register(object instance, string pathInfo = null)
         {
             throw new NotImplementedException();
         }
@@ -1311,14 +1311,6 @@ namespace Grapevine.Tests.Server
     }
 
     public class MethodsToRegister
-    {
-        [RestRoute]
-        public IHttpContext Method(IHttpContext context) { return context; }
-    }
-
-    
-    [RestResource(BasePath = "/api")]
-    public class RoutesFromInstance
     {
         [RestRoute]
         public IHttpContext Method(IHttpContext context) { return context; }

--- a/src/Grapevine.Tests/Server/RouterFacts.cs
+++ b/src/Grapevine.Tests/Server/RouterFacts.cs
@@ -792,6 +792,18 @@ namespace Grapevine.Tests.Server
             }
 
             [Fact]
+            public void RegistersInstance()
+            {
+                var router = new Router();
+                router.RoutingTable.ShouldBeEmpty();
+
+                router.Register(new RoutesFromInstance(), "v2");
+
+                router.RoutingTable.Count.ShouldBe(1);
+                router.RoutingTable.First().PathInfo.ShouldContain("v2/api");
+            }
+
+            [Fact]
             public void RegistersAssembly()
             {
                 var router = new Router();
@@ -1267,6 +1279,11 @@ namespace Grapevine.Tests.Server
             throw new NotImplementedException();
         }
 
+        public IRouter Register<T>(T instance, string pathInfo = null) where T : class
+        {
+            throw new NotImplementedException();
+        }
+
         public IRouter Register(Assembly assembly)
         {
             throw new NotImplementedException();
@@ -1294,6 +1311,14 @@ namespace Grapevine.Tests.Server
     }
 
     public class MethodsToRegister
+    {
+        [RestRoute]
+        public IHttpContext Method(IHttpContext context) { return context; }
+    }
+
+    
+    [RestResource(BasePath = "/api")]
+    public class RoutesFromInstance
     {
         [RestRoute]
         public IHttpContext Method(IHttpContext context) { return context; }

--- a/src/Grapevine/Interfaces/Server/HttpResponse.cs
+++ b/src/Grapevine/Interfaces/Server/HttpResponse.cs
@@ -310,10 +310,15 @@ namespace Grapevine.Interfaces.Server
             {
                 Response.ContentLength64 = contents.Length;
                 Response.OutputStream.Write(contents, 0, contents.Length);
+                Response.OutputStream.Close();
+            }
+            catch
+            {
+                Response.OutputStream.Dispose();
+                throw;
             }
             finally
             {
-                Response.OutputStream.Close();
                 Advanced.Close();
             }
         }

--- a/src/Grapevine/Server/HttpResponseExtensions.cs
+++ b/src/Grapevine/Server/HttpResponseExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Text;
 using Grapevine.Interfaces.Server;
+using Grapevine.Interfaces.Shared;
 using Grapevine.Shared;
 using HttpStatusCode = Grapevine.Shared.HttpStatusCode;
 
@@ -177,6 +177,18 @@ namespace Grapevine.Server
                 : stream.GetBinaryBytes();
 
             response.SendResponse(buffer);
+        }
+
+        public static void TrySendResponse(this IHttpResponse response, IGrapevineLogger logger, HttpStatusCode status, Exception e = null)
+        {
+            try
+            {
+                response.SendResponse(status, e);
+            }
+            catch (Exception ex)
+            {
+                logger.Log(new LogEvent { Exception = ex, Level = LogLevel.Error, Message = "Failed to send response" });
+            }
         }
     }
 }

--- a/src/Grapevine/Server/Route.cs
+++ b/src/Grapevine/Server/Route.cs
@@ -108,9 +108,10 @@ namespace Grapevine.Server
         /// <param name="methodInfo"></param>
         /// <param name="httpMethod"></param>
         /// <param name="pathInfo"></param>
-        public Route(MethodInfo methodInfo, HttpMethod httpMethod, string pathInfo) : this(httpMethod, pathInfo)
+        /// <param name="methodHolderInstance"></param>
+        public Route(MethodInfo methodInfo, HttpMethod httpMethod, string pathInfo, object methodHolderInstance = null) : this(httpMethod, pathInfo)
         {
-            Function = ConvertMethodToFunc(methodInfo);
+            Function = ConvertMethodToFunc(methodInfo, methodHolderInstance);
             Name = $"{methodInfo.ReflectedType.FullName}.{methodInfo.Name}";
             Description = $"{HttpMethod} {PathInfo} > {Name}";
         }
@@ -249,8 +250,9 @@ namespace Grapevine.Server
         /// Returns a generic delegate for the given MethodInfo if it is rest route eligible
         /// </summary>
         /// <param name="method"></param>
+        /// <param name="instance"></param>
         /// <returns></returns>
-        public static Func<IHttpContext, IHttpContext> ConvertMethodToFunc(MethodInfo method)
+        public static Func<IHttpContext, IHttpContext> ConvertMethodToFunc(MethodInfo method, object instance = null)
         {
             method.IsRestRouteEligible(true); // throws an aggregate exception if the method is not eligible
 
@@ -263,7 +265,7 @@ namespace Grapevine.Server
             // Generates new instance every time
             return context =>
             {
-                var instance = Activator.CreateInstance(method.ReflectedType);
+                instance = instance ?? Activator.CreateInstance(method.ReflectedType);
                 var disposed = false;
                 try
                 {

--- a/src/Grapevine/Server/Router.cs
+++ b/src/Grapevine/Server/Router.cs
@@ -276,7 +276,7 @@ namespace Grapevine.Server
         /// <param name="pathInfo">base path</param>
         /// <typeparam name="T"></typeparam>
         /// <returns>IRouter</returns>
-        IRouter Register<T>(T instance, string pathInfo = null) where T:class;
+        IRouter Register(object instance, string pathInfo = null); //where T:class;
 
         /// <summary>
         /// Adds all RestRoutes found in all RestResources in the specified assembly to the routing table
@@ -526,7 +526,7 @@ namespace Grapevine.Server
             return Register(typeof(T));
         }
 
-        public IRouter Register<T>(T instance, string pathInfo = null) where T:class
+        public IRouter Register(object instance, string pathInfo = null) //where T:class
         {
             AppendRoutingTable(Scanner.ScanInstance(instance, pathInfo));
             return this;

--- a/src/Grapevine/Server/Router.cs
+++ b/src/Grapevine/Server/Router.cs
@@ -270,6 +270,15 @@ namespace Grapevine.Server
         IRouter Register<T>();
 
         /// <summary>
+        /// Adds all RestRoutes in the specified instance to the routing table
+        /// </summary>
+        /// <param name="instance">Instance of a class that contains public Routes</param>
+        /// <param name="pathInfo">base path</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>IRouter</returns>
+        IRouter Register<T>(T instance, string pathInfo = null) where T:class;
+
+        /// <summary>
         /// Adds all RestRoutes found in all RestResources in the specified assembly to the routing table
         /// </summary>
         /// <returns>IRouter</returns>
@@ -515,6 +524,12 @@ namespace Grapevine.Server
         public IRouter Register<T>()
         {
             return Register(typeof(T));
+        }
+
+        public IRouter Register<T>(T instance, string pathInfo = null) where T:class
+        {
+            AppendRoutingTable(Scanner.ScanInstance(instance, pathInfo));
+            return this;
         }
 
         public IRouter Register(Assembly assembly)

--- a/src/Grapevine/Server/Router.cs
+++ b/src/Grapevine/Server/Router.cs
@@ -554,19 +554,11 @@ namespace Grapevine.Server
 
                 if (context.WasRespondedTo) return;
 
-                if (e is NotFoundException)
-                {
-                    context.Response.SendResponse(HttpStatusCode.NotFound, SendExceptionMessages ? e.Message : null);
-                    return;
-                }
+                var status = (context.Response.StatusCode == HttpStatusCode.Ok) ? HttpStatusCode.InternalServerError : context.Response.StatusCode;
+                if (e is NotFoundException) status = HttpStatusCode.NotFound;
+                if (e is NotImplementedException) status = HttpStatusCode.NotImplemented;
 
-                if (e is NotImplementedException)
-                {
-                    context.Response.SendResponse(HttpStatusCode.NotImplemented, SendExceptionMessages ? e.Message : null);
-                    return;
-                }
-
-                context.Response.SendResponse(HttpStatusCode.InternalServerError, SendExceptionMessages ? e : null);
+                context.Response.TrySendResponse(Logger, status, SendExceptionMessages ? e : null);
             }
         }
 


### PR DESCRIPTION
I needed a call to the server to trigger an event in my wpf app, using this I can register the event from the instance of the class containing the routes, then pass the instance to the router
it used to be _\<T\>_ but that took over calls to Register(IRouter)

thanks for the lib, it's super fun to use